### PR TITLE
Ep 689/add side menu & titles from details page

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@codegouvfr/react-dsfr": "^0.73.0",
+        "@codegouvfr/react-dsfr": "^0.73.5",
+        "@emotion/react": "^11.11.1",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -22,6 +23,7 @@
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.14.2",
         "react-scripts": "5.0.1",
+        "tss-react": "^4.8.8",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
       }
@@ -2024,9 +2026,9 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "node_modules/@codegouvfr/react-dsfr": {
-      "version": "0.73.0",
-      "resolved": "https://registry.npmjs.org/@codegouvfr/react-dsfr/-/react-dsfr-0.73.0.tgz",
-      "integrity": "sha512-QYXRF1LkRzlyfZNW2wYYX/HgeUAT0Su3sxWTbgWrpDdwml6bBpVCg4PWXT7ikCx1MU6tDdiKO3knueYFR9FOew==",
+      "version": "0.73.5",
+      "resolved": "https://registry.npmjs.org/@codegouvfr/react-dsfr/-/react-dsfr-0.73.5.tgz",
+      "integrity": "sha512-x8mXPfmCLcbnGee1zn41521BkeltBtteYTejp4Q65iWpmddgGLarQOPh9GjRxfyU3WSW2yMaicQQfFRr4HLtxA==",
       "dependencies": {
         "tsafe": "^1.6.3"
       },
@@ -2304,6 +2306,128 @@
       "peerDependencies": {
         "postcss-selector-parser": "^6.0.10"
       }
+    },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz",
+      "integrity": "sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.1",
+        "@emotion/memoize": "^0.8.1",
+        "@emotion/serialize": "^1.1.2",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.11.0.tgz",
+      "integrity": "sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==",
+      "dependencies": {
+        "@emotion/memoize": "^0.8.1",
+        "@emotion/sheet": "^1.2.2",
+        "@emotion/utils": "^1.2.1",
+        "@emotion/weak-memoize": "^0.3.1",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
+      "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
+    },
+    "node_modules/@emotion/react": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.1.tgz",
+      "integrity": "sha512-5mlW1DquU5HaxjLkfkGN1GA/fvVGdyHURRiX/0FHl2cfIfRxSOfmxEH5YS43edp0OldZrZ+dkBKbngxcNCdZvA==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.11.0",
+        "@emotion/cache": "^11.11.0",
+        "@emotion/serialize": "^1.1.2",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
+        "@emotion/utils": "^1.2.1",
+        "@emotion/weak-memoize": "^0.3.1",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.2.tgz",
+      "integrity": "sha512-zR6a/fkFP4EAcCMQtLOhIgpprZOwNmCldtpaISpvz348+DP4Mz8ZoKaGGCQpbzepNIUWbq4w6hNZkwDyKoS+HA==",
+      "dependencies": {
+        "@emotion/hash": "^0.9.1",
+        "@emotion/memoize": "^0.8.1",
+        "@emotion/unitless": "^0.8.1",
+        "@emotion/utils": "^1.2.1",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.2.tgz",
+      "integrity": "sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA=="
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
+      "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz",
+      "integrity": "sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.1.tgz",
+      "integrity": "sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg=="
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
+      "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww=="
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -8029,6 +8153,11 @@
         "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
       }
     },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -8657,6 +8786,19 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/hoopy": {
       "version": "0.1.4",
@@ -15571,6 +15713,11 @@
         "postcss": "^8.2.15"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
+    },
     "node_modules/sucrase": {
       "version": "3.34.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.34.0.tgz",
@@ -16073,6 +16220,26 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+    },
+    "node_modules/tss-react": {
+      "version": "4.8.8",
+      "resolved": "https://registry.npmjs.org/tss-react/-/tss-react-4.8.8.tgz",
+      "integrity": "sha512-V57AU6J42LLhYhRGSxDVi9VLUaoQtV6y2Kb1e0uqabe3w61G9R8gkUiX4DHZUReboRY9rwExPWz0LVZIgqQ98Q==",
+      "dependencies": {
+        "@emotion/cache": "*",
+        "@emotion/serialize": "*",
+        "@emotion/utils": "*"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.4.1",
+        "@emotion/server": "^11.4.0",
+        "react": "^16.8.0 || ^17.0.2 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/server": {
+          "optional": true
+        }
+      }
     },
     "node_modules/tsutils": {
       "version": "3.21.0",

--- a/front/package.json
+++ b/front/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@codegouvfr/react-dsfr": "^0.73.0",
+    "@codegouvfr/react-dsfr": "^0.73.5",
+    "@emotion/react": "^11.11.1",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
@@ -16,6 +17,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.14.2",
     "react-scripts": "5.0.1",
+    "tss-react": "^4.8.8",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
   },

--- a/front/src/components/Footer.tsx
+++ b/front/src/components/Footer.tsx
@@ -6,10 +6,10 @@ function Footer() {
       accessibility="fully compliant"
       contentDescription=""
       termsLinkProps={{
-        to: '#',
+        href: '#',
       }}
       websiteMapLinkProps={{
-        to: '#',
+        href: '#',
       }}
     />
   );

--- a/front/src/components/Header.tsx
+++ b/front/src/components/Header.tsx
@@ -33,7 +33,7 @@ function Header() {
         {
           iconId: 'fr-icon-github-fill',
           linkProps: {
-            to: '#',
+            to: 'https://github.com/betagouv/espace-partenaire',
           },
           text: 'Github',
         },

--- a/front/src/components/Page.tsx
+++ b/front/src/components/Page.tsx
@@ -1,13 +1,14 @@
+import React from 'react';
 import Footer from './Footer';
 import Header from './Header';
 
 function Page(props: { children: JSX.Element }) {
   return (
-    <>
+    <React.Fragment>
       <Header />
       {props.children}
       <Footer />
-    </>
+    </React.Fragment>
   );
 }
 

--- a/front/src/components/Title1.tsx
+++ b/front/src/components/Title1.tsx
@@ -1,10 +1,4 @@
-import React from 'react';
-
-function Title1(props: any) {
-  return (
-    <React.Fragment>
-      <h1 className="fr-mt-6v">{props.title}</h1>
-    </React.Fragment>
-  );
+function Title1(props: { title: string }) {
+  return <h1 className="fr-mt-6v">{props.title}</h1>;
 }
 export default Title1;

--- a/front/src/components/Title2.tsx
+++ b/front/src/components/Title2.tsx
@@ -1,11 +1,5 @@
-import React from 'react';
-
-function Title2(props: any) {
-  const { title } = props;
-  return (
-    <React.Fragment>
-      <h2 className="fr-h6">{title}</h2>
-    </React.Fragment>
-  );
+function Title2(props: { title: string; id?: string }) {
+  const { title, id } = props;
+  return <h2 id={id}>{title}</h2>;
 }
 export default Title2;

--- a/front/src/pages/ProvidersDetails/ProviderAuthorization.tsx
+++ b/front/src/pages/ProvidersDetails/ProviderAuthorization.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import Title2 from '../../components/Title2';
+
+export const ProviderAuthorization = () => {
+  return <Title2 title="Habilitation" id="authorization" />;
+};

--- a/front/src/pages/ProvidersDetails/ProviderDescription.tsx
+++ b/front/src/pages/ProvidersDetails/ProviderDescription.tsx
@@ -1,3 +1,9 @@
+import Title2 from '../../components/Title2';
+
 export const ProviderDescription = () => {
-  return <></>;
+  return (
+    <div className="fr-col-12 fr-col-md">
+      <Title2 title="Description" id="description" />
+    </div>
+  );
 };

--- a/front/src/pages/ProvidersDetails/ProviderDetails.tsx
+++ b/front/src/pages/ProvidersDetails/ProviderDetails.tsx
@@ -1,7 +1,13 @@
 import Title1 from '../../components/Title1';
 import { makeStyles } from 'tss-react/dsfr';
-import Title2 from '../../components/Title2';
 import { Button } from '@codegouvfr/react-dsfr/Button';
+import { SideMenu } from './ProviderSideMenu';
+import { ProviderDescription } from './ProviderDescription';
+import { ProviderKey } from './ProviderKey';
+import { ProviderUrl } from './ProviderUrl';
+import { ProviderScope } from './ProviderScope';
+import { ProviderSave } from './ProviderSave';
+import { ProviderAuthorization } from './ProviderAuthorization';
 
 export function ProviderDetails() {
   const { classes, cx } = useStyles();
@@ -14,7 +20,9 @@ export function ProviderDetails() {
         MonComptePro !
       </p>
       <div className={`${cx(classes.root)} fr-py-6v fr-px-4v`}>
-        <Title2 title="Documentation" />
+        <p>
+          <b>Documentation</b>
+        </p>
         <p>
           Retrouvez toutes les informations dont vous avez besoin et nos
           guidelines graphiques dans l'espace de documentation.
@@ -22,6 +30,19 @@ export function ProviderDetails() {
         <Button iconId="fr-icon-book-2-line" priority="secondary">
           Lire la documentation
         </Button>
+      </div>
+      <div className="fr-container--fluid fr-mt-10v">
+        <div className="fr-grid-row">
+          <SideMenu></SideMenu>
+          <div className="fr-col-12 fr-col-md">
+            <ProviderDescription></ProviderDescription>
+            <ProviderKey></ProviderKey>
+            <ProviderUrl></ProviderUrl>
+            <ProviderScope></ProviderScope>
+            <ProviderSave></ProviderSave>
+            <ProviderAuthorization></ProviderAuthorization>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/front/src/pages/ProvidersDetails/ProviderKey.tsx
+++ b/front/src/pages/ProvidersDetails/ProviderKey.tsx
@@ -1,3 +1,6 @@
+import React from 'react';
+import Title2 from '../../components/Title2';
+
 export const ProviderKey = () => {
-  return <></>;
+  return <Title2 title="Clés" id="keys" />;
 };

--- a/front/src/pages/ProvidersDetails/ProviderSave.tsx
+++ b/front/src/pages/ProvidersDetails/ProviderSave.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import Title2 from '../../components/Title2';
+
+export const ProviderSave = () => {
+  return <Title2 title="Sauvegarde" id="save" />;
+};

--- a/front/src/pages/ProvidersDetails/ProviderScope.tsx
+++ b/front/src/pages/ProvidersDetails/ProviderScope.tsx
@@ -1,3 +1,6 @@
+import React from 'react';
+import Title2 from '../../components/Title2';
+
 export const ProviderScope = () => {
-  return <></>;
+  return <Title2 title="Champs" id="scopes" />;
 };

--- a/front/src/pages/ProvidersDetails/ProviderSideMenu.tsx
+++ b/front/src/pages/ProvidersDetails/ProviderSideMenu.tsx
@@ -1,0 +1,58 @@
+import { SideMenu as MuiSideMenu } from '@codegouvfr/react-dsfr/SideMenu';
+
+const MENU_WIDTH = 300;
+
+export const SideMenu = () => {
+  return (
+    <div
+      className="fr-col-12 fr-col-md-3"
+      style={{
+        width: MENU_WIDTH,
+      }}
+    >
+      <MuiSideMenu
+        align="left"
+        burgerMenuButtonText="Dans cette rubrique"
+        items={[
+          {
+            isActive: true,
+            linkProps: {
+              to: '#description',
+            },
+            text: 'Description',
+          },
+          {
+            linkProps: {
+              to: '#keys',
+            },
+            text: 'Clés',
+          },
+          {
+            linkProps: {
+              to: '#url',
+            },
+            text: 'URL',
+          },
+          {
+            linkProps: {
+              to: '#scopes',
+            },
+            text: 'Champs',
+          },
+          {
+            linkProps: {
+              to: '#save',
+            },
+            text: 'Sauvegarde',
+          },
+          {
+            linkProps: {
+              to: '#authorization',
+            },
+            text: 'Habilitation',
+          },
+        ]}
+      />
+    </div>
+  );
+};

--- a/front/src/pages/ProvidersDetails/ProviderUrl.tsx
+++ b/front/src/pages/ProvidersDetails/ProviderUrl.tsx
@@ -1,3 +1,6 @@
+import React from 'react';
+import Title2 from '../../components/Title2';
+
 export const ProviderUrl = () => {
-  return <></>;
+  return <Title2 title="URL" id="url" />;
 };

--- a/front/src/pages/ProvidersList/EspaceList.tsx
+++ b/front/src/pages/ProvidersList/EspaceList.tsx
@@ -2,8 +2,10 @@ import axios from 'axios';
 import React from 'react';
 import { useState } from 'react';
 
+type listType = Array<{ title: string; description: string }>;
+
 export const EspaceList = () => {
-  const [list, setList] = useState<any[]>([]);
+  const [list, setList] = useState<listType>([]);
 
   React.useEffect(() => {
     axios.get('http://localhost:3000/list').then((response) => {
@@ -15,7 +17,7 @@ export const EspaceList = () => {
     <div className="fr-container">
       <div>Hello world list</div>
       <ul>
-        {list.map(({ title, description }, index: any) => (
+        {list.map(({ title, description }, index) => (
           <li key={index}>
             {title} && {description}
           </li>


### PR DESCRIPTION
## 🎯 Objectif

Ajouter le SideMenu et les titres associées aux ancres. Ce ne fut pas une partie de plaisir à cause de la questions des ancres 🥵 mais grâce à cette PR @garronej a pu faire une amélioration - sur la fonctionnalité des ancres - sur react-dsfr. l'amélioration est visible sur [cette PR](https://github.com/codegouvfr/react-dsfr/commit/d6f2de5c1d90a54240c5ca21fefabff171d95d1b). 🎉🎉🎉

Du coup cette PR contient une mise à jour du `package.json` & `package-lock.json`.

J'en ai profité pour ajouter le lien github, supprimer les balises vides afin de les remplacer par `<React.Fragment>`.

J'ai aussi supprimé tous les types `any` de TypeScript, car cela m'a induite en erreur plusieurs heures. Merci @BenoitSerrano ❤️