### PR TITLE
EP-705/add copy function for keys

### DIFF
--- a/back/package.json
+++ b/back/package.json
@@ -61,7 +61,7 @@
       "json",
       "ts"
     ],
-    "rootDir": "src",
+    "rootDir": "test",
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"

--- a/back/src/app.controller.ts
+++ b/back/src/app.controller.ts
@@ -1,9 +1,14 @@
 import { Controller, Get } from '@nestjs/common';
 import { AppService } from './app.service';
+import { KeysGenerator } from './keys/KeysGenerator';
+import { ClientKeys } from './type';
 
 @Controller()
 export class AppController {
-  constructor(private readonly appService: AppService) {}
+  constructor(
+    private readonly appService: AppService,
+    private readonly keysGenerator: KeysGenerator
+  ) {}
 
   @Get('/welcome')
   getHello(): string {
@@ -13,5 +18,9 @@ export class AppController {
   @Get('/list')
   getList(): any[] {
     return this.appService.getList();
+  }
+  @Get('/keys')
+  getKeys(): ClientKeys {
+    return this.keysGenerator.generate();
   }
 }

--- a/back/src/app.module.ts
+++ b/back/src/app.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { KeysGenerator } from './keys/KeysGenerator';
 
 @Module({
   imports: [],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [AppService, KeysGenerator],
 })
 export class AppModule {}

--- a/back/src/app.service.ts
+++ b/back/src/app.service.ts
@@ -5,7 +5,7 @@ export class AppService {
   getHello(): string {
     return 'Bonjour, bienvenue dans votre nouvel espace partenaires';
   }
-  getList(): Array<any> {
+  getList(): Array<{ title: string; description: string }> {
     return [
       { title: 'AgentConnect0', description: 'blablabla' },
       { title: 'AgentConnect2', description: 'blablabla' },

--- a/back/src/keys/KeysGenerator.ts
+++ b/back/src/keys/KeysGenerator.ts
@@ -1,0 +1,10 @@
+import { ClientKeys } from 'src/type';
+import { randomBytes } from 'crypto';
+
+export class KeysGenerator {
+  generate(): ClientKeys {
+    const clientId = randomBytes(64).toString('hex');
+    const clientSecret = randomBytes(64).toString('hex');
+    return { clientId, clientSecret };
+  }
+}

--- a/back/src/type.ts
+++ b/back/src/type.ts
@@ -1,0 +1,4 @@
+export type ClientKeys = {
+  clientId: string;
+  clientSecret: string;
+};

--- a/back/test/unit/app.controller.spec.ts
+++ b/back/test/unit/app.controller.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { AppController } from './app.controller';
-import { AppService } from './app.service';
+import { AppController } from '../../src/app.controller';
+import { AppService } from '../../src/app.service';
+import { KeysGenerator } from '../../src/keys/KeysGenerator';
 
 describe('AppController', () => {
   let appController: AppController;
@@ -8,7 +9,7 @@ describe('AppController', () => {
   beforeEach(async () => {
     const app: TestingModule = await Test.createTestingModule({
       controllers: [AppController],
-      providers: [AppService],
+      providers: [AppService, KeysGenerator],
     }).compile();
 
     appController = app.get<AppController>(AppController);
@@ -16,7 +17,9 @@ describe('AppController', () => {
 
   describe('root', () => {
     it('should return "Hello World!"', () => {
-      expect(appController.getHello()).toBe('Hello World!');
+      expect(appController.getHello()).toBe(
+        'Bonjour, bienvenue dans votre nouvel espace partenaires'
+      );
     });
   });
 });

--- a/back/test/unit/keys-generator.spec.ts
+++ b/back/test/unit/keys-generator.spec.ts
@@ -1,0 +1,18 @@
+import { KeysGenerator } from '../../src/keys/KeysGenerator';
+
+describe('KeyGenerator', () => {
+  let keysGenerator: KeysGenerator;
+
+  beforeAll(async () => {
+    keysGenerator = new KeysGenerator();
+  });
+
+  describe('KeysGenerator', () => {
+    it('should return 2 differents keys', () => {
+      const { clientId, clientSecret } = keysGenerator.generate();
+      expect(clientId).not.toBeNull();
+      expect(clientSecret).not.toBeNull();
+      expect(clientId).not.toBe(clientSecret);
+    });
+  });
+});

--- a/front/src/lib/api.ts
+++ b/front/src/lib/api.ts
@@ -1,0 +1,20 @@
+import axios from 'axios';
+
+const api = {
+  getKeys,
+  getList,
+};
+
+const BASE_URL = 'http://localhost:3000';
+
+async function getKeys() {
+  const response = await axios.get(BASE_URL + '/keys');
+  return response.data;
+}
+
+async function getList() {
+  const response = await axios.get(BASE_URL + '/list');
+  return response.data;
+}
+
+export { api };

--- a/front/src/pages/ProvidersDetails/ProviderKey.tsx
+++ b/front/src/pages/ProvidersDetails/ProviderKey.tsx
@@ -1,9 +1,30 @@
 import Title2 from '../../components/Title2';
 import { Input } from '@codegouvfr/react-dsfr/Input';
 import { Button } from '@codegouvfr/react-dsfr/Button';
-import { copyToClipBoard } from '../../utils';
+import React, { useState } from 'react';
+import { api } from '../../lib/api';
+
+const copyToClipBoard = (value: string) => {
+  navigator.clipboard.writeText(value);
+};
 
 export const ProviderKey = () => {
+  const [clientID, setClientID] = useState('');
+  const [clientSecret, setClientSecret] = useState('');
+
+  React.useEffect(() => {
+    async function fetchData() {
+      try {
+        const data = await api.getKeys();
+        setClientID(data.clientId);
+        setClientSecret(data.clientSecret);
+      } catch (error) {
+        console.error('Error fetching data:', error);
+      }
+    }
+    fetchData();
+  }, []);
+
   return (
     <div className="fr-mb-10v">
       <Title2 title="Clés" id="keys" />
@@ -14,14 +35,13 @@ export const ProviderKey = () => {
             className="fr-col-md-7 fr-mb-0"
             label="ClientID"
             nativeInputProps={{
-              value: '',
+              value: clientID,
             }}
           />
           <Button
-            disabled
             className="fr-ml-2v"
             iconId="fr-icon-clipboard-line"
-            onClick={() => copyToClipBoard()}
+            onClick={() => copyToClipBoard(clientID)}
             priority="tertiary"
           >
             Copier
@@ -30,12 +50,18 @@ export const ProviderKey = () => {
       </div>
       <div className="fr-container--fluid">
         <div className="fr-grid-row fr-grid-row--bottom fr-mt-5v">
-          <Input disabled className="fr-col-md-7 fr-mb-0" label="ClientID" />
-          <Button
+          <Input
             disabled
+            className="fr-col-md-7 fr-mb-0"
+            label="ClientSecret"
+            nativeInputProps={{
+              value: clientSecret,
+            }}
+          />
+          <Button
             className="fr-ml-2v"
             iconId="fr-icon-clipboard-line"
-            onClick={() => copyToClipBoard()}
+            onClick={() => copyToClipBoard(clientSecret)}
             priority="tertiary"
           >
             Copier

--- a/front/src/pages/ProvidersList/EspaceList.tsx
+++ b/front/src/pages/ProvidersList/EspaceList.tsx
@@ -1,6 +1,6 @@
-import axios from 'axios';
 import React from 'react';
 import { useState } from 'react';
+import { api } from '../../lib/api';
 
 type listType = Array<{ title: string; description: string }>;
 
@@ -8,9 +8,15 @@ export const EspaceList = () => {
   const [list, setList] = useState<listType>([]);
 
   React.useEffect(() => {
-    axios.get('http://localhost:3000/list').then((response) => {
-      setList(response.data);
-    });
+    async function fetchData() {
+      try {
+        const data = await api.getList();
+        setList(data);
+      } catch (error) {
+        console.error('Error fetching data:', error);
+      }
+    }
+    fetchData();
   }, []);
 
   return (


### PR DESCRIPTION
## 🎯 Objectif

Générer (back), récupérer, afficher et copier (front) les client ID et client secret.
Ajoute fichier `type.ts` pour répertorier les typages précis de typescript.
Extrait la logique dans le back et le front (appels api/générer les clés).
Ajoute les premiers tests jests.